### PR TITLE
Fix setQuery usage in documentation

### DIFF
--- a/src/guides/components/request.md
+++ b/src/guides/components/request.md
@@ -43,7 +43,7 @@ async function sendRequest(sdk: SDK): Promise<void> {
   spec.setHost("example.com");
   spec.setPort(443);
   spec.setPath("/");
-  spec.setQuery("?query=test")
+  spec.setQuery("query=test")
   spec.setTls(true);
 ```
 
@@ -102,7 +102,7 @@ async function sendRequest(sdk: SDK): Promise<void> {
   spec.setHost("example.com");
   spec.setPort(443);
   spec.setPath("/");
-  spec.setQuery("?query=test")
+  spec.setQuery("query=test")
   spec.setTls(true);
 
   let sentRequest = await sdk.requests.send(spec);


### PR DESCRIPTION
I was following the documentation and it seems things have changed since this piece was written.
setQuery adds the preceding question mark so proper usage is not to include the leading question mark in the input
Otherwise your request will be like /path??param=val